### PR TITLE
Improve update-packages skill to use Snyk for major-version upgrades

### DIFF
--- a/.claude/skills/update-packages/SKILL.md
+++ b/.claude/skills/update-packages/SKILL.md
@@ -6,14 +6,18 @@ model: haiku
 
 # Update Packages
 
-Updates all project dependencies and opens a PR for review. The mechanical,
-deterministic work lives in a bundled bash script so the workflow is reliable
-enough for a small model to drive.
+Updates all project dependencies — including major-version bumps where Snyk
+shows they're needed to clear a vulnerability — and opens a PR for review.
+The mechanical, deterministic work lives in a bundled bash script so the
+workflow is reliable enough for a small model to drive; the Snyk MCP tools
+handle the part that needs judgment (deciding *which* packages need a major
+upgrade).
 
 ## How it works
 
 Run the subcommands of `scripts/update-packages.sh` (in this skill directory,
-from the repo root) in order. The script prints clearly-prefixed status lines:
+from the repo root) in order, and call the Snyk MCP tools where instructed.
+The script prints clearly-prefixed status lines:
 
 - `OK:` step succeeded — continue
 - `STOP:` nothing to do — end cleanly (this is **not** an error)
@@ -21,16 +25,37 @@ from the repo root) in order. The script prints clearly-prefixed status lines:
 
 ## Steps
 
-1. **Update** — `bash .claude/skills/update-packages/scripts/update-packages.sh update`
+1. **Update in-range** — `bash .claude/skills/update-packages/scripts/update-packages.sh update`
    - Switches to `main`, pulls, creates the `update-packages` branch, runs
-     `pnpm update`, verifies with `pnpm build`, and commits the changes.
-   - On `STOP:` (no dependency changes), stop here and report that everything is already up to date.
+     `pnpm update` (which only moves packages within their current semver
+     range), verifies with `pnpm build`, and commits the changes.
+   - On `STOP:` (no in-range changes), the branch is kept open — continue to step 2 anyway, since a major-version upgrade may still be needed.
    - On `FAIL: pnpm build failed …`, investigate the build error, fix it, then re-run from step 1.
 
-2. **Open PR** — `bash .claude/skills/update-packages/scripts/update-packages.sh pr`
+2. **Check whether any package needs a major-version upgrade** — call the
+   `mcp__Snyk__snyk_sca_scan` MCP tool with `path` set to the absolute repo
+   root (get it with `pwd`) and `dev: true`.
+   - If the tool reports the folder isn't trusted, call `mcp__Snyk__snyk_trust` with the same path and re-run the scan.
+   - For each reported vulnerability that has a fixed/upgrade version, compare that version's major version to the one currently installed (check `package.json` / `pnpm-lock.yaml`):
+     - Same major version → `pnpm update` in step 1 already covers it (or will once available in-range) — ignore it.
+     - Higher major version required to fix it → note the package name; it needs a forced major upgrade.
+   - You can cross-check a specific package/version with `mcp__Snyk__snyk_package_health_check` (ecosystem `npm`) before committing to the upgrade, e.g. to confirm the new major isn't itself flagged as unmaintained.
+   - No packages need a major bump → skip to step 4.
+
+3. **Apply each major upgrade** — for every package identified in step 2, run:
+   `bash .claude/skills/update-packages/scripts/update-packages.sh major <package-name>`
+   - Force-upgrades that one package past its semver range (`pnpm update <package> --latest`), verifies with `pnpm build`, and commits it as its own change (so the PR diff stays easy to review per-package).
+   - On `STOP:`, that package was already current — move on to the next one.
+   - On `FAIL: pnpm build failed …`, investigate the break that specific major upgrade caused (it's usually a breaking-change migration), fix it, amend nothing — just fix the code, stage it, and re-run `major <package-name>` so the fix lands in the same commit.
+
+4. **Nothing to do?** If neither step 1 nor step 3 produced any commits, run
+   `bash .claude/skills/update-packages/scripts/update-packages.sh abort` to
+   clean up the branch, then stop and report everything is already up to date.
+
+5. **Open PR** — `bash .claude/skills/update-packages/scripts/update-packages.sh pr`
    - Pushes the branch and opens a PR. Note the `PR_NUMBER=` line in the output.
 
-3. **Merge** — `bash .claude/skills/update-packages/scripts/update-packages.sh merge <pr-number>`
+6. **Merge** — `bash .claude/skills/update-packages/scripts/update-packages.sh merge <pr-number>`
    - Watches the PR checks. If they pass, it merges, switches back to `main`, pulls, and deletes the `update-packages` branch locally and remotely.
    - On `FAIL: … checks failed`, do **NOT** merge — report the failing checks.
 

--- a/.claude/skills/update-packages/scripts/update-packages.sh
+++ b/.claude/skills/update-packages/scripts/update-packages.sh
@@ -9,11 +9,14 @@
 #   FAIL:  needs attention — read the output, fix, then re-run
 #
 # Subcommands:
-#   update   checkout main, pull, branch, `pnpm update`, `pnpm build`, commit
-#   pr       push the branch and open a PR; prints the PR number
-#   merge N  watch checks for PR N, merge if green, then clean up branches
+#   update      checkout main, pull, branch, `pnpm update`, `pnpm build`, commit
+#   major PKG   force-upgrade PKG past its semver range (`pnpm update --latest`),
+#               `pnpm build`, commit as a separate change
+#   abort       no updates were made on the branch — clean up and stop
+#   pr          push the branch and open a PR; prints the PR number
+#   merge N     watch checks for PR N, merge if green, then clean up branches
 #
-# Usage: .claude/scripts/update-packages.sh <update|pr|merge> [pr-number]
+# Usage: .claude/scripts/update-packages.sh <update|major|abort|pr|merge> [arg]
 
 set -euo pipefail
 
@@ -43,9 +46,7 @@ cmd_update() {
   pnpm update || die "pnpm update failed"
 
   if [ -z "$(git status --porcelain package.json pnpm-lock.yaml)" ]; then
-    echo "STOP: no dependency changes — all packages already up to date"
-    git checkout main
-    git branch -D "${BRANCH}"
+    echo "STOP: no in-range dependency changes — branch kept open to check for major-version upgrades next"
     exit 0
   fi
 
@@ -56,7 +57,42 @@ cmd_update() {
   git add package.json pnpm-lock.yaml
   git commit -m "${COMMIT_MSG}" || die "git commit failed"
 
-  echo "OK: update complete — next run 'pr'"
+  echo "OK: update complete — next check for major-version upgrades"
+}
+
+cmd_major() {
+  command -v pnpm >/dev/null 2>&1 || die "pnpm is not installed"
+  pkg="${1:-}"
+  [ -n "${pkg}" ] || die "major requires a package name: major <package>"
+
+  echo "OK: force-upgrading ${pkg} to its latest version (ignoring its semver range)"
+  pnpm update "${pkg}" --latest || die "pnpm update --latest failed for ${pkg}"
+
+  if [ -z "$(git status --porcelain package.json pnpm-lock.yaml)" ]; then
+    echo "STOP: ${pkg} is already at its latest version — nothing to do"
+    exit 0
+  fi
+
+  echo "OK: running pnpm build to verify the major upgrade of ${pkg}"
+  pnpm build || die "pnpm build failed after upgrading ${pkg} — investigate and fix before re-running"
+
+  echo "OK: committing major upgrade of ${pkg}"
+  git add package.json pnpm-lock.yaml
+  git commit -m "chore: Upgrade ${pkg} to latest major version" || die "git commit failed"
+
+  echo "OK: major upgrade of ${pkg} complete"
+}
+
+cmd_abort() {
+  [ "$(git branch --show-current)" = "${BRANCH}" ] || die "not on ${BRANCH} — nothing to abort"
+  if [ -n "$(git log main.."${BRANCH}" --oneline)" ]; then
+    die "refusing to abort — ${BRANCH} has commits ahead of main"
+  fi
+
+  echo "OK: no updates were made — cleaning up ${BRANCH}"
+  git checkout main || die "could not switch to main"
+  git branch -D "${BRANCH}"
+  echo "STOP: nothing to update — all packages already up to date"
 }
 
 cmd_pr() {
@@ -68,7 +104,7 @@ cmd_pr() {
   echo "OK: creating PR"
   gh pr create --base main --head "${BRANCH}" \
     --title "${PR_TITLE}" \
-    --body "Automated dependency update via the update-packages workflow." \
+    --body "Automated dependency update via the update-packages workflow, including any major-version upgrades Snyk identified as necessary to clear a vulnerability." \
     || die "gh pr create failed"
 
   pr_number="$(gh pr view "${BRANCH}" --json number --jq .number)" \
@@ -102,7 +138,9 @@ cmd_merge() {
 
 case "${1:-}" in
   update) cmd_update ;;
+  major)  shift; cmd_major "$@" ;;
+  abort)  cmd_abort ;;
   pr)     cmd_pr ;;
   merge)  shift; cmd_merge "$@" ;;
-  *)      die "unknown subcommand '${1:-}' — use: update | pr | merge <pr-number>" ;;
+  *)      die "unknown subcommand '${1:-}' — use: update | major <package> | abort | pr | merge <pr-number>" ;;
 esac


### PR DESCRIPTION
Adds a Snyk SCA scan step that identifies packages whose vulnerabilities require a major-version bump (which plain `pnpm update` won't apply), and new `major`/`abort` script subcommands to apply and clean up accordingly.