### PR TITLE
Stop forcing haiku model for update-packages skill

### DIFF
--- a/.claude/skills/update-packages/SKILL.md
+++ b/.claude/skills/update-packages/SKILL.md
@@ -1,17 +1,15 @@
 ---
 name: update-packages
 description: Update all project dependencies and create a PR for review. Use when the user wants to update/upgrade npm/pnpm packages, bump dependencies, or run the update-packages workflow.
-model: haiku
 ---
 
 # Update Packages
 
 Updates all project dependencies — including major-version bumps where Snyk
 shows they're needed to clear a vulnerability — and opens a PR for review.
-The mechanical, deterministic work lives in a bundled bash script so the
-workflow is reliable enough for a small model to drive; the Snyk MCP tools
-handle the part that needs judgment (deciding *which* packages need a major
-upgrade).
+The mechanical, deterministic work lives in a bundled bash script, keeping
+the workflow reliable; the Snyk MCP tools handle the part that needs
+judgment (deciding *which* packages need a major upgrade).
 
 ## How it works
 


### PR DESCRIPTION
## Summary
- Removes the `model: haiku` frontmatter from the update-packages skill so it inherits the model from the invoking session instead of always running on haiku
- Updates the skill description to drop the now-inaccurate "reliable enough for a small model to drive" rationale

## Test plan
- [x] Frontmatter no longer pins a model
- [ ] Verify the skill runs correctly when invoked from a session using a different model